### PR TITLE
Fix npm 10 install

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -132,13 +132,11 @@ const buildExecScript = (packages: PackageDefinition[], prefix: string | undefin
     {},
   );
 
-  const directory = isEmpty(prefix) ? js`path.dirname(__dirname)` : js`path.dirname(path.dirname(__dirname))`;
-
   const code = js`#!/usr/bin/env node
 const path = require('path');
 const child_process = require('child_process');
 const mapping = ${mapping};
-const modulesDirectory = ${directory};
+const modulesDirectory = __dirname;
 const definition = mapping[process.platform + '_' + process.arch];
 const packageName = definition.name.join('/');
 const packageJsonPath = require.resolve(packageName + '/package.json', { paths: [modulesDirectory] });

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash';
 import { join, sep } from 'node:path';
 import { parse as parsePath } from 'path';
 import { findFiles, parseArtifactsFile, parseMetadata, validateBinaryArtifact, writePackage } from '../core/files';
@@ -136,10 +135,8 @@ const buildExecScript = (packages: PackageDefinition[], prefix: string | undefin
 const path = require('path');
 const child_process = require('child_process');
 const mapping = ${mapping};
-const modulesDirectory = __dirname;
 const definition = mapping[process.platform + '_' + process.arch];
-const packageName = definition.name.join('/');
-const packageJsonPath = require.resolve(packageName + '/package.json', { paths: [modulesDirectory] });
+const packageJsonPath = require.resolve(definition.name.join('/') + '/package.json');
 const packagePath = path.join(path.dirname(packageJsonPath), definition.bin);
 child_process.spawn(packagePath, process.argv.splice(2), {
   stdio: 'inherit',


### PR DESCRIPTION
npm 10 will install the optional package inside the package:

```
../lib/node_modules
❯ tree
.
└── @bytemain
    └── x-dev
        ├── index.js
        ├── node_modules
        │   └── @bytemain
        │       └── x-dev_darwin_arm64
        │           ├── x-dev
        │           └── package.json
        └── package.json

```

so we should use `require.resolve` to find the real package path