### PR TITLE
feat: package license support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,12 @@ const keywordsOption = <T>(builder: Argv<T>) =>
     describe: 'Keywords for the npm package',
   });
 
+const licenseOption = <T>(builder: Argv<T>) =>
+  builder.option('license', {
+    type: 'string',
+    describe: 'Package license / SPDX identifier',
+  });
+
 void scriptName('goreleaser-npm-publisher')
   .version(__VERSION__)
   .usage('$0 <cmd> [args]')
@@ -97,7 +103,8 @@ void scriptName('goreleaser-npm-publisher')
         .then(descriptionOption)
         .then(filesOption)
         .then(keywordsOption)
-        .then(verboseOption),
+        .then(verboseOption)
+        .then(licenseOption),
     options => buildHandler(options),
     [isDistEmptyCheck as never, createDistFolder as never, initLogger as never],
   )
@@ -114,7 +121,8 @@ void scriptName('goreleaser-npm-publisher')
         .then(filesOption)
         .then(keywordsOption)
         .then(tokenOption)
-        .then(verboseOption),
+        .then(verboseOption)
+        .then(licenseOption),
     options => publishHandler(options),
     [isDistEmptyCheck as never, createDistFolder as never, initLogger as never],
   )

--- a/src/core/package/transform.ts
+++ b/src/core/package/transform.ts
@@ -2,7 +2,13 @@ import { isEmpty, uniq } from 'lodash';
 import { normalizeArch } from './arch';
 import { normalizeOS } from './os';
 
-export const transformPackage = (artifact: BinaryArtifact, metadata: Metadata, files: string[], keywords: string[]): PackageDefinition => {
+export const transformPackage = (
+  artifact: BinaryArtifact,
+  metadata: Metadata,
+  files: string[],
+  keywords: string[],
+  license?: string,
+): PackageDefinition => {
   return {
     name: `${metadata.project_name}_${artifact.goos}_${artifact.goarch}`,
     version: metadata.version,
@@ -13,6 +19,7 @@ export const transformPackage = (artifact: BinaryArtifact, metadata: Metadata, f
     destinationBinary: artifact.path,
     files,
     keywords,
+    license,
   };
 };
 
@@ -32,6 +39,7 @@ export const formatPackageJson = (
     cpu: [pkg.cpu],
     files,
     keywords,
+    license: pkg.license,
   });
 
 export const formatPackageName = (pkg: PackageDefinition | Metadata, prefix: string | undefined): string => {
@@ -49,6 +57,7 @@ export const formatMainPackageJson = (
   prefix: string | undefined,
   files: string[],
   keywords: string[],
+  license?: string,
 ): PackageJson =>
   normalize({
     name: formatPackageName(metadata, prefix),
@@ -66,6 +75,7 @@ export const formatMainPackageJson = (
     cpu: uniq(packages.map(pkg => pkg.cpu)),
     files,
     keywords,
+    license: license,
   });
 
 const normalize = ({ description, ...other }: PackageJson): PackageJson => {

--- a/src/types/package-def.d.ts
+++ b/src/types/package-def.d.ts
@@ -11,6 +11,7 @@ interface PackageDefinition {
   cpu: CPU;
   files: string[];
   keywords: string[];
+  license?: string;
 }
 
 interface PackageJson {
@@ -23,4 +24,5 @@ interface PackageJson {
   cpu: CPU[];
   files: string[];
   keywords: string[];
+  license?: string;
 }

--- a/src/types/params.d.ts
+++ b/src/types/params.d.ts
@@ -10,6 +10,7 @@ interface ListParams {
 interface BuildParams extends ListParams {
   clear: boolean;
   files: string[];
+  license?: string;
 }
 
 interface PublishParams extends BuildParams {


### PR DESCRIPTION
Add support for `license` declaration in package.json. This is needed so `npm` doesn't report the license as "none"