### PR TITLE
feat: add NPM OTP support for two-factor authentication

### DIFF
--- a/src/cli-error-handler.spec.ts
+++ b/src/cli-error-handler.spec.ts
@@ -1,5 +1,3 @@
-import { NpmExecError } from './npm';
-
 const mockError = jest.fn();
 
 jest.mock('./core/logger', () => ({
@@ -8,14 +6,13 @@ jest.mock('./core/logger', () => ({
   },
 }));
 
+import { NpmExecError } from './npm';
 import { handleCliError } from './cli-error-handler';
 
 describe('handleCliError', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit');
-    });
+    mockError.mockClear();
+    jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
   });
 
   afterEach(() => {
@@ -30,12 +27,13 @@ describe('handleCliError', () => {
         detail: 'Open this URL...',
       });
 
-      expect(() => handleCliError('fallback message', err)).toThrow('process.exit');
+      handleCliError('fallback message', err);
 
       expect(mockError).toHaveBeenCalledWith(
         'ERROR: NPM requires a one-time password (OTP). Provide it with --otp <code>.',
       );
-      expect(process.exit).toHaveBeenCalledWith(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(jest.mocked(process.exit)).toHaveBeenCalledWith(1);
     });
   });
 
@@ -47,10 +45,11 @@ describe('handleCliError', () => {
         detail: 'You are not allowed to publish this package',
       });
 
-      expect(() => handleCliError('Custom error message', err)).toThrow('process.exit');
+      handleCliError('Custom error message', err);
 
       expect(mockError).toHaveBeenCalledWith('ERROR: Custom error message');
-      expect(process.exit).toHaveBeenCalledWith(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(jest.mocked(process.exit)).toHaveBeenCalledWith(1);
     });
   });
 
@@ -58,19 +57,21 @@ describe('handleCliError', () => {
     it('should log provided message with ERROR prefix', () => {
       const err = new Error('Network timeout');
 
-      expect(() => handleCliError('Connection failed', err)).toThrow('process.exit');
+      handleCliError('Connection failed', err);
 
       expect(mockError).toHaveBeenCalledWith('ERROR: Connection failed');
-      expect(process.exit).toHaveBeenCalledWith(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(jest.mocked(process.exit)).toHaveBeenCalledWith(1);
     });
   });
 
   describe('message without error', () => {
     it('should log message with ERROR prefix', () => {
-      expect(() => handleCliError('Command failed')).toThrow('process.exit');
+      handleCliError('Command failed');
 
       expect(mockError).toHaveBeenCalledWith('ERROR: Command failed');
-      expect(process.exit).toHaveBeenCalledWith(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(jest.mocked(process.exit)).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/src/cli-error-handler.spec.ts
+++ b/src/cli-error-handler.spec.ts
@@ -1,0 +1,76 @@
+import { NpmExecError } from './npm';
+
+const mockError = jest.fn();
+
+jest.mock('./core/logger', () => ({
+  logger: {
+    error: mockError,
+  },
+}));
+
+import { handleCliError } from './cli-error-handler';
+
+describe('handleCliError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('EOTP error', () => {
+    it('should log OTP-specific message with ERROR prefix', () => {
+      const err = new NpmExecError({
+        code: 'EOTP',
+        summary: 'This operation requires a one-time password.',
+        detail: 'Open this URL...',
+      });
+
+      expect(() => handleCliError('fallback message', err)).toThrow('process.exit');
+
+      expect(mockError).toHaveBeenCalledWith(
+        'ERROR: NPM requires a one-time password (OTP). Provide it with --otp <code>.',
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('other NPM errors', () => {
+    it('should fall back to provided message for unknown error codes', () => {
+      const err = new NpmExecError({
+        code: 'E403',
+        summary: 'Forbidden',
+        detail: 'You are not allowed to publish this package',
+      });
+
+      expect(() => handleCliError('Custom error message', err)).toThrow('process.exit');
+
+      expect(mockError).toHaveBeenCalledWith('ERROR: Custom error message');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('non-npm error', () => {
+    it('should log provided message with ERROR prefix', () => {
+      const err = new Error('Network timeout');
+
+      expect(() => handleCliError('Connection failed', err)).toThrow('process.exit');
+
+      expect(mockError).toHaveBeenCalledWith('ERROR: Connection failed');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('message without error', () => {
+    it('should log message with ERROR prefix', () => {
+      expect(() => handleCliError('Command failed')).toThrow('process.exit');
+
+      expect(mockError).toHaveBeenCalledWith('ERROR: Command failed');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/cli-error-handler.ts
+++ b/src/cli-error-handler.ts
@@ -1,21 +1,26 @@
 import { logger } from './core/logger';
 import { NpmExecError } from './npm';
 
-export const handleCliError = (msg: string, err?: Error): void => {
-  if (err instanceof NpmExecError) {
-    logger.error(`ERROR: ${handleNpmExecError(err) ?? msg}`);
+export const handleCliError = (msg?: string, err?: Error): void => {
+  const message = getMessage(err);
+  if (message) {
+    logger.error(`ERROR: ${message}`);
   } else {
-    logger.error(`ERROR: ${msg}`);
+    logger.error(`ERROR: ${msg ?? err?.message}`);
   }
 
   process.exit(1);
 };
 
-const handleNpmExecError = (err: NpmExecError): string | null => {
-  switch (err.code) {
-    case 'EOTP':
-      return 'NPM requires a one-time password (OTP). Provide it with --otp <code>.';
-    default:
-      return null;
+const getMessage = (err?: Error): string | null => {
+  if (err instanceof NpmExecError) {
+    switch (err.code) {
+      case 'EOTP':
+        return 'NPM requires a one-time password (OTP). Provide it with --otp <code>.';
+      default:
+        return null;
+    }
   }
+
+  return null;
 };

--- a/src/cli-error-handler.ts
+++ b/src/cli-error-handler.ts
@@ -1,0 +1,21 @@
+import { logger } from './core/logger';
+import { NpmExecError } from './npm';
+
+export const handleCliError = (msg: string, err?: Error): void => {
+  if (err instanceof NpmExecError) {
+    logger.error(`ERROR: ${handleNpmExecError(err) ?? msg}`);
+  } else {
+    logger.error(`ERROR: ${msg}`);
+  }
+
+  process.exit(1);
+};
+
+const handleNpmExecError = (err: NpmExecError): string | null => {
+  switch (err.code) {
+    case 'EOTP':
+      return 'NPM requires a one-time password (OTP). Provide it with --otp <code>.';
+    default:
+      return null;
+  }
+};

--- a/src/cli.options.ts
+++ b/src/cli.options.ts
@@ -49,6 +49,12 @@ export const tokenOption = <T>(builder: Argv<T>) =>
     describe: 'Token for the npm package',
   });
 
+export const otpOption = <T>(builder: Argv<T>) =>
+  builder.option('otp', {
+    type: 'string',
+    describe: 'One-time password for npm two-factor authentication',
+  });
+
 export const verboseOption = <T>(builder: Argv<T>) =>
   builder.option('verbose', {
     type: 'boolean',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   filesOption,
   keywordsOption,
   licenseOption,
+  otpOption,
   prefixOption,
   projectOption,
   tokenOption,
@@ -67,6 +68,7 @@ void cli
         .then(filesOption)
         .then(keywordsOption)
         .then(tokenOption)
+        .then(otpOption)
         .then(verboseOption)
         .then(licenseOption),
     (options: PublishParams) => publishHandler(options),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import yargs, { type Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { buildHandler, listHandler, publishHandler } from './commands';
 import { ConsoleLogger, setLogger } from './core/logger';
+import { handleCliError } from './cli-error-handler';
 import { createDistFolder, isDistEmptyCheck } from './helpers';
 import {
   builderOption,
@@ -75,6 +76,7 @@ void cli
     [isDistEmptyCheck as never, createDistFolder as never],
   )
   .demandCommand(1, 'You need at least one command before moving on to the next step')
+  .fail((msg, err) => handleCliError(msg, err))
   .showHelpOnFail(false, 'Specify --help for available options')
   .wrap(Math.min(100, cli.terminalWidth()))
   .global('project')

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -13,7 +13,7 @@ export const publishHandler: ActionType<PublishParams> = async args => {
   const packageFolders = sortBy(await readdir(context.distPath), p => -p.length);
   for (const packageFolder of packageFolders) {
     logger.info(context.packageFolder(packageFolder));
-    const packageInfo = await publish(context.packageFolder(packageFolder), { token: args.token });
+    const packageInfo = await publish(context.packageFolder(packageFolder), { token: args.token, otp: args.otp });
     await logger.group(`Successfully published ${packageInfo.id}`, async () => {
       logger.info(`Name: ${packageInfo.name}`);
       logger.info(`Version: ${packageInfo.version}`);

--- a/src/npm/index.ts
+++ b/src/npm/index.ts
@@ -1,2 +1,3 @@
+export * from './error';
 export * from './publish';
 export * from './whoami';

--- a/src/npm/models.ts
+++ b/src/npm/models.ts
@@ -1,5 +1,6 @@
 export interface BaseOptions {
   token?: string;
+  otp?: string;
 }
 
 export interface ErrorResponse {
@@ -33,6 +34,7 @@ export interface File {
 export interface NpmExecContext {
   pwd?: string;
   token?: string;
+  otp?: string;
 }
 
 export type NpmExecAction<T> = (env: Record<string, string>) => Promise<T>;

--- a/src/npm/publish.spec.ts
+++ b/src/npm/publish.spec.ts
@@ -3,26 +3,71 @@ jest.mock('./exec', () => ({ npmExec: npmExecMock }));
 
 import { publish } from './publish';
 
+const mockResponse = {
+  id: 'pkg@1.0.0',
+  name: 'pkg',
+  version: '1.0.0',
+  size: 100,
+  unpackedSize: 200,
+  shasum: 'abc',
+  integrity: 'sha512-abc',
+  filename: 'pkg-1.0.0.tgz',
+  files: [],
+  entryCount: 0,
+  bundled: [],
+};
+
+beforeEach(() => {
+  npmExecMock.mockResolvedValue(mockResponse);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('publish', () => {
-  it('should call npmExec with publish args', async () => {
-    npmExecMock.mockResolvedValue({ id: 'pkg@1.0.0' });
+  it('should publish with --access public', async () => {
+    await publish('/some/path');
+    const args = npmExecMock.mock.calls[0][0] as string[];
+    expect(args).toContain('--access');
+    expect(args).toContain('public');
+  });
 
-    await publish('/tmp/pkg', { token: 'abc' });
+  it('should pass token to exec context', async () => {
+    await publish('/some/path', { token: 'mytoken' });
+    const context = npmExecMock.mock.calls[0][1] as { token?: string };
+    expect(context.token).toBe('mytoken');
+  });
 
-    expect(npmExecMock).toHaveBeenCalledWith(['publish', '--access', 'public'], {
-      pwd: '/tmp/pkg',
-      token: 'abc',
-    });
+  it('should not include --otp flag when otp is not provided', async () => {
+    await publish('/some/path');
+    const args = npmExecMock.mock.calls[0][0] as string[];
+    expect(args).not.toContain('--otp');
+  });
+
+  it('should include --otp flag when otp is provided', async () => {
+    await publish('/some/path', { otp: '123456' });
+    const args = npmExecMock.mock.calls[0][0] as string[];
+    expect(args).toContain('--otp');
+    expect(args).toContain('123456');
+  });
+
+  it('should pass otp to exec context', async () => {
+    await publish('/some/path', { otp: '123456' });
+    const context = npmExecMock.mock.calls[0][1] as { otp?: string };
+    expect(context.otp).toBe('123456');
+  });
+
+  it('should pass pwd to exec context', async () => {
+    await publish('/some/path');
+    const context = npmExecMock.mock.calls[0][1] as { pwd?: string };
+    expect(context.pwd).toBe('/some/path');
   });
 
   it('should work without arguments', async () => {
-    npmExecMock.mockResolvedValue({ id: 'pkg@1.0.0' });
-
     await publish();
-
-    expect(npmExecMock).toHaveBeenCalledWith(['publish', '--access', 'public'], {
-      pwd: undefined,
-      token: undefined,
-    });
+    const context = npmExecMock.mock.calls[0][1] as { pwd?: string; token?: string };
+    expect(context.pwd).toBeUndefined();
+    expect(context.token).toBeUndefined();
   });
 });

--- a/src/npm/publish.spec.ts
+++ b/src/npm/publish.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 const npmExecMock = jest.fn();
 jest.mock('./exec', () => ({ npmExec: npmExecMock }));
 

--- a/src/npm/publish.ts
+++ b/src/npm/publish.ts
@@ -2,8 +2,14 @@ import { npmExec } from './exec';
 import { BaseOptions, PublishResponse } from './models';
 
 export const publish = async (path?: string, options?: BaseOptions) => {
-  return npmExec<PublishResponse>(['publish', '--access', 'public'], {
+  const args = ['publish', '--access', 'public'];
+  if (options?.otp) {
+    args.push('--otp', options.otp);
+  }
+
+  return npmExec<PublishResponse>(args, {
     pwd: path,
     token: options?.token,
+    otp: options?.otp,
   });
 };

--- a/src/types/params.d.ts
+++ b/src/types/params.d.ts
@@ -15,4 +15,5 @@ interface BuildParams extends ListParams {
 
 interface PublishParams extends BuildParams {
   token?: string;
+  otp?: string;
 }


### PR DESCRIPTION
Adds --otp CLI option to the publish command, passing the one-time password to npm publish via the --otp flag.